### PR TITLE
Adicionado NumericDamageEffect

### DIFF
--- a/CuberZ/Assets/-Game/Prefabs/Effects.meta
+++ b/CuberZ/Assets/-Game/Prefabs/Effects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c878374040baad74da05ec5cd85dd6b2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CuberZ/Assets/-Game/Prefabs/Effects/Numeric Damage Effect.prefab
+++ b/CuberZ/Assets/-Game/Prefabs/Effects/Numeric Damage Effect.prefab
@@ -1,0 +1,196 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4284705373044273160
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4284705373044273163}
+  - component: {fileID: 4284705373044273162}
+  - component: {fileID: 4284705373044273161}
+  m_Layer: 5
+  m_Name: Damage Effect
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4284705373044273163
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4284705373044273160}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
+  m_Children: []
+  m_Father: {fileID: 4284705373430382147}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 300, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4284705373044273162
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4284705373044273160}
+  m_CullTransparentMesh: 0
+--- !u!114 &4284705373044273161
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4284705373044273160}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.67290825, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 100
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: 100
+--- !u!1 &4284705373430382158
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4284705373430382147}
+  - component: {fileID: 4284705373430382146}
+  - component: {fileID: 4284705373430382145}
+  - component: {fileID: 4284705373430382144}
+  - component: {fileID: 4284705373430382159}
+  m_Layer: 5
+  m_Name: Numeric Damage Effect
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4284705373430382147
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4284705373430382158}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4284705373044273163}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 3, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4284705373430382146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4284705373430382158}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc006b6ebb0dcda478159e2b95d34c46, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  effectDuration: 1
+  fadeStartAt: 0.75
+  scalingFactor: 1.5
+  scalingProportion: 0.5
+  upSpeed: 3
+--- !u!223 &4284705373430382145
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4284705373430382158}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 1
+  m_TargetDisplay: 0
+--- !u!114 &4284705373430382144
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4284705373430382158}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!114 &4284705373430382159
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4284705373430382158}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295

--- a/CuberZ/Assets/-Game/Prefabs/Effects/Numeric Damage Effect.prefab.meta
+++ b/CuberZ/Assets/-Game/Prefabs/Effects/Numeric Damage Effect.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9eaf83c622183ad43a4490a09dbefd86
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CuberZ/Assets/-Game/Scripts/Effects.meta
+++ b/CuberZ/Assets/-Game/Scripts/Effects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ad9f1839cb7cec245a27b71caea48750
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CuberZ/Assets/-Game/Scripts/Effects/NumericDamageEffect.cs
+++ b/CuberZ/Assets/-Game/Scripts/Effects/NumericDamageEffect.cs
@@ -1,0 +1,161 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class NumericDamageEffect : MonoBehaviour
+{
+    #region Variáveis "Públicas"
+
+    [Header("Configurações do Efeito")]
+    [Tooltip("Duração total do efeito.")]
+    [SerializeField] private float effectDuration = 1f;
+
+    [Range(0f, 1f)]
+    [Tooltip("Em que momento do efeito o fade inicia?")]
+    [SerializeField] private float fadeStartAt = 0.75f;
+
+    [Min(1f)]
+    [Tooltip("Quanto será o escalonamento do efeito?")]
+    [SerializeField] private float scalingFactor = 1.5f;
+
+    [Range(0f, 1f)]
+    [Tooltip("Proporção de tempo de quando aumenta a escala e quando diminui.")]
+    [SerializeField] private float scalingTimeProportion = 0.5f;
+    [Tooltip("Velocidade em que o efeito se move para cima.")]
+    [SerializeField] private float upSpeed = 3f;
+
+    #endregion
+
+    #region Variáveis Privadas
+
+    //Texto cujo número aparecerá, e também onde todas as configurações do efeito serão aplicadas
+    private Text damageEffect_;
+
+    //Cor inicial do efeito
+    private Color myColor_;
+    //Cor do fade, igual à cor inicial, mas com o alfa transparente
+    private Color fadeColor_;
+    //Escala inicial do efeito
+    private Vector3 myScale_;
+    //Escala com o scalingFactor aplicado
+    private Vector3 newScale_;
+
+    //Timer da duração total do efeito
+    private float timer_ = 0f;
+    //Lerp usado no fade
+    private float fadeLerp_ = 0f;
+    //Lerp usado para aumentar a escala
+    private float scaleUpLerp_ = 0f;
+    //Lerp usado para diminuir a escala
+    private float scaleDownLerp_ = 0f;
+
+    //Transform da câmera, para não ficar usando Camera.main a cada frame
+    private Transform mainCamera_;
+
+    #endregion
+
+    #region Função Pública para a Configuração do Efeito
+
+    //Função a ser chamada para ativar o efeito:
+    //Por motivos de evitar bugs, ela reseta todas as variáveis que precisam ser resetadas,
+    //atribui o valor do dano ao texto do efeito
+    //e, por fim, ativa o texto do efeito em si.
+    public void SetUpEffect(int damageAmount)
+    {
+        timer_ = 0f;
+        fadeLerp_ = 0f;
+        scaleUpLerp_ = 0f;
+        scaleDownLerp_ = 0f;
+
+        newScale_ = myScale_ * scalingFactor;
+
+        damageEffect_.transform.localPosition = Vector3.zero;
+        damageEffect_.transform.localScale = myScale_;
+        damageEffect_.color = myColor_;
+
+        damageEffect_.text = damageAmount.ToString();
+
+        damageEffect_.gameObject.SetActive(true);
+    }
+
+    #endregion
+
+    #region Funções MonoBehaviour
+
+    //Atribuição padrão de algumas variáveis
+    private void Awake()
+    {
+        damageEffect_ = GetComponentInChildren<Text>();
+
+        myScale_ = damageEffect_.transform.localScale;
+
+        myColor_ = damageEffect_.color;
+        fadeColor_ = new Color(myColor_.r, myColor_.g, myColor_.b, 0);
+
+        damageEffect_.gameObject.SetActive(false);
+        mainCamera_ = Camera.main.transform;
+    }
+
+    //Update só funcionará se damageEffect estiver ativado, ou seja, se a função SetUpEffect tiver sido chamada
+    private void Update()
+    {
+        if (!damageEffect_.gameObject.activeInHierarchy) return;
+
+        timer_ += Time.deltaTime;
+
+        Scale();
+        Fade();
+        End();
+
+        damageEffect_.transform.position += Vector3.up * upSpeed * Time.deltaTime;
+        transform.rotation = mainCamera_.rotation;
+    }
+
+    #endregion
+
+    #region Funções do Efeito
+
+    //Atinge a nova escala e depois retorna para a anterior tendo como base a proporção de tempo configurada
+    private void Scale()
+    {
+        if (timer_ < effectDuration * scalingTimeProportion)
+        {
+            scaleUpLerp_ += Time.deltaTime / (effectDuration * scalingTimeProportion);
+            if (scaleUpLerp_ > 1) scaleUpLerp_ = 1;
+
+            damageEffect_.transform.localScale = Vector3.Lerp(myScale_, newScale_, scaleUpLerp_);
+        }
+        else
+        {
+            scaleDownLerp_ += Time.deltaTime / (effectDuration - effectDuration * scalingTimeProportion);
+            if (scaleDownLerp_ > 1) scaleDownLerp_ = 1;
+
+            damageEffect_.transform.localScale = Vector3.Lerp(newScale_, myScale_, scaleDownLerp_);
+        }
+    }
+
+    //Começa a desaparecer a partir do momento configurado na proporção do tempo para iniciar o fade
+    private void Fade()
+    {
+        if (timer_ >= effectDuration * fadeStartAt)
+        {
+            fadeLerp_ += Time.deltaTime / (effectDuration - effectDuration * fadeStartAt);
+            if (fadeLerp_ > 1) fadeLerp_ = 1;
+
+            damageEffect_.color = Color.Lerp(myColor_, fadeColor_, fadeLerp_);
+        }
+    }
+
+    //Após atingir o tempo de duração total, simplesmente desativa o damageEffect, isso faz com que o Update pare de ser executado
+    private void End()
+    {
+        if (timer_ >= effectDuration)
+        {
+            timer_ = 0;
+            damageEffect_.gameObject.SetActive(false);
+        }
+    }
+
+    #endregion
+}

--- a/CuberZ/Assets/-Game/Scripts/Effects/NumericDamageEffect.cs.meta
+++ b/CuberZ/Assets/-Game/Scripts/Effects/NumericDamageEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc006b6ebb0dcda478159e2b95d34c46
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Adicionado Script NumericDamageEffect que permite configurar pelo Inspector:
- A duração total do efeito;
- Em que momento do efeito o fade inicia;
- A proporção de escalonamento;
- A distribuição do tempo de escalonamento;
- E a velocidade que o efeito se deslocará para cima.
* Criado Prefab Numeric Damage Effect;
* Adicionadas novas pastas Effect.